### PR TITLE
Hotfixes to issue #2

### DIFF
--- a/lib/libzdf.py
+++ b/lib/libzdf.py
@@ -52,7 +52,7 @@ class libzdf(lm4):
 
 	def libZdfListMain(self):
 		l = []
-		l.append({'metadata':{'name':self.translation(32031)}, 'params':{'mode':'libZdfListPage','url':f'{self.baseApi}/content/documents/meist-gesehen-100.json?profile=default'}, 'type':'dir'})
+		#l.append({'metadata':{'name':self.translation(32031)}, 'params':{'mode':'libZdfListPage','url':f'{self.baseApi}/content/documents/meist-gesehen-100.json?profile=default'}, 'type':'dir'})
 		#l.append({'metadata':{'name':self.translation(32031)}, 'params':{'mode':'libZdfListPage','url':f'{self.baseApi}/content/documents/filter-meist-gesehen-100.json?profile=page-video_episode_vod&limit=50'}, 'type':'dir'})
 		l.append({'metadata':{'name':self.translation(32132)}, 'params':{'mode':'libZdfListShows'}, 'type':'dir'})
 		l.append({'metadata':{'name':self.translation(32133)}, 'params':{'mode':'libZdfListChannel'}, 'type':'dir'})
@@ -90,4 +90,3 @@ class libzdf(lm4):
 	def libZdfListSearch(self,searchString):
 		self.params['url'] = f'{self.baseApi}/search/documents?q={searchString}'
 		return self.libZdfListPage()
-			

--- a/lib/libzdfjsonparser.py
+++ b/lib/libzdfjsonparser.py
@@ -204,7 +204,12 @@ class parser:
 		elif target['contentType'] in ['brand','category','topic']:
 			if not target.get('hasVideo', False): return False
 
-			self.d['params']['url'] = self.baseApi + target['http://zdf.de/rels/search/page-video-counter-with-video']['self'].replace('&limit=0','&limit=100')
+			try:
+				t = target["http://zdf.de/rels/search/page-video-counter-with-video"]["self"]
+			except KeyError:
+				return False
+
+			self.d['params']['url'] = self.baseApi + t.replace('&limit=0','&limit=100')
 			self.d['params']['mode'] = 'libZdfListPage'
 			self.d['type'] = 'dir'
 

--- a/lib/libzdfjsonparser.py
+++ b/lib/libzdfjsonparser.py
@@ -195,15 +195,14 @@ class parser:
 		self._grepActors(target)
 
 		if target['contentType'] == 'topic':
-			if target['hasVideo'] == False: return False
+			if not target.get('hasVideo', False): return False
 
 			self.d['params']['url'] = self.baseApi + target['self']+'&limit=100'
 			self.d['params']['mode'] = 'libZdfListPage'
 			self.d['type'] = 'dir'
 
 		elif target['contentType'] in ['brand','category','topic']:
-			if not 'hasVideo' in target: return False
-			if target['hasVideo'] == False: return False
+			if not target.get('hasVideo', False): return False
 
 			self.d['params']['url'] = self.baseApi + target['http://zdf.de/rels/search/page-video-counter-with-video']['self'].replace('&limit=0','&limit=100')
 			self.d['params']['mode'] = 'libZdfListPage'
@@ -220,7 +219,7 @@ class parser:
 			except: self.d = False
 
 		elif target['contentType'] == 'episode':# or target['contentType'] == 'clip':
-			if not target['hasVideo']:
+			if not target.get('hasVideo', False):
 				pass
 				#return False
 			#if target['mainVideoContent']['http://zdf.de/rels/target']['showCaption']:
@@ -259,7 +258,7 @@ class parser:
 		
 	def _grepArt(self,target,isVideo=False):
 		art = {}
-		if not isVideo:
+		if not isVideo and 'teaserImageRef' in target:
 			if 'layouts' in target['teaserImageRef']:
 				if '384xauto' in target['teaserImageRef']['layouts']:
 					self.d['metadata']['art']['thumb'] = target['teaserImageRef']['layouts']['384xauto']


### PR DESCRIPTION
This is what I did to get the plugin running again for me (resonably well). One bug in "Sendungen A-Z" seems to remain, but I failed to reproduce it consistently. Retry works.

* Disable "Meistgesehen" entry, as its endpoint is gone
* fix "hasVideo" KeyErrors in "Sendungen A-Z"
* Skip if something in "Rubriken" doesn't have a thumbnail